### PR TITLE
resolve and reject return a promise (with tests)

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,13 @@
     "type": "git",
     "url": "git+https://github.com/blockai/empty-promise.git"
   },
-  "keywords": ["promise", "es6", "wait", "resolve", "reject"],
+  "keywords": [
+    "promise",
+    "es6",
+    "wait",
+    "resolve",
+    "reject"
+  ],
   "author": "Oli Lalonde <olalonde@gmail.com> (https://syskall.com/)",
   "license": "MIT",
   "bugs": {

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,13 @@ export default () => {
   const p = new Promise((resolve, reject) => {
     callbacks = { resolve, reject }
   })
-  p.resolve = callbacks.resolve
-  p.reject = callbacks.reject
+  p.resolve = (val) => {
+    callbacks.resolve(val)
+    return p
+  }
+  p.reject = (val) => {
+    callbacks.reject(val)
+    return p
+  }
   return p
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -26,3 +26,36 @@ test('reject', (t) => {
     wait.reject(new Error('some error'))
   })
 })
+
+test('resolve returns original promise', (t) => {
+  const wait = emptyPromise()
+
+  const result = wait.resolve('some value')
+
+  t.equal(result instanceof Promise, true)
+  t.equal(result, wait)
+
+  t.end()
+})
+
+test('reject returns original promise', (t) => {
+  const wait = emptyPromise()
+
+  const result = wait.reject('some value')
+
+  t.equal(result instanceof Promise, true)
+  t.equal(result, wait)
+
+  result.catch(() => { /* ignore */ })
+  t.end()
+})
+
+test('receive resolved value after `await`ing resolve', (t) => {
+  (async () => {
+    const wait = emptyPromise()
+    const result = await wait.resolve('some value')
+
+    t.equal(result, 'some value')
+    t.end()
+  })()
+})


### PR DESCRIPTION

---

I love how you came up with the same pun for the same feature as me 😉 and implemented  it basically the same way I did.

I've updated this to return the original promise when resolving or rejecting, helps with some types of chaining and improves compatibility with async/await. New tests written and passing (along with the old ones of course). 

_Note:_ I did not touch `package.json` myself. Npm edited it during install. I guess they have changed their formatting a bit.

---

I'm curious why you think an empty promise "[in] general, should be avoided.". I see this as a vast improvement over native API if used correctly, because you can pass around promises as simple tokens instead of state-machines.
