### PR TITLE
commonjs + done

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,15 +1,22 @@
 module.exports = () => {
   let callbacks
+  let done = false
+
   const p = new Promise((resolve, reject) => {
     callbacks = { resolve, reject }
   })
+
+  p.done = () => done
   p.resolve = (val) => {
     callbacks.resolve(val)
+    done = true
     return p
   }
   p.reject = (val) => {
     callbacks.reject(val)
+    done = true
     return p
   }
+
   return p
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-export default () => {
+module.exports = () => {
   let callbacks
   const p = new Promise((resolve, reject) => {
     callbacks = { resolve, reject }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -41,7 +41,7 @@ test('resolve returns original promise', (t) => {
 test('reject returns original promise', (t) => {
   const wait = emptyPromise()
 
-  const result = wait.reject('some value')
+  const result = wait.reject('some error')
 
   t.equal(result instanceof Promise, true)
   t.equal(result, wait)
@@ -50,12 +50,39 @@ test('reject returns original promise', (t) => {
   t.end()
 })
 
-test('receive resolved value after `await`ing resolve', (t) => {
+test('receive resolved value after awaiting resolve', (t) => {
   (async () => {
     const wait = emptyPromise()
     const result = await wait.resolve('some value')
 
     t.equal(result, 'some value')
+    t.end()
+  })()
+})
+
+test('done returns false if promise not resolved', (t) => {
+  const wait = emptyPromise()
+  t.equal(wait.done(), false)
+  wait.resolve().then(() => t.end())
+})
+
+test('done returns true after promise resolved', (t) => {
+  (async () => {
+    const wait = emptyPromise()
+    await wait.resolve('some value')
+
+    t.equal(wait.done(), true)
+    t.end()
+  })()
+})
+
+test('done returns true after promise rejected', (t) => {
+  (async () => {
+    const wait = emptyPromise()
+    await wait.reject('some error')
+      .catch(() => { /* ignore */ })
+
+    t.equal(wait.done(), true)
     t.end()
   })()
 })


### PR DESCRIPTION
* First commit changes export to nodejs/commonjs style export. This works just as well with es6 `import`, but also allows use with `require`.
* Second commit adds `done` method to check status of promise. This allows avoidance of trying to generate data to push into a promise that no longer accepts new data.